### PR TITLE
Feature nanotubes

### DIFF
--- a/simncad/INCLUDE/WRAPPER/NC_Wrapper.h
+++ b/simncad/INCLUDE/WRAPPER/NC_Wrapper.h
@@ -22,6 +22,14 @@ class NC_Cell;
 //typedef long id_t;
 typedef DWORD64 id_t;
 
+typedef struct 
+{
+    string cell;
+    double n;
+    double m;
+} NC_NanotubeLayer;
+
+
 /**Class that represents an atom */
 //------------------------------------------------------------------------------
 class NC_WRAPPER_EXPORT NC_Atom
@@ -159,7 +167,21 @@ public:
 */  
   virtual ERR DoAction(const NC_Bond  &Bond) = 0;
 };
+//------------------------------------------------------------------------------
+class NC_WRAPPER_EXPORT NC_Nanotube
+//------------------------------------------------------------------------------
+{
+public:
+    NC_Nanotube();
+    ~NC_Nanotube();
 
+    void AddLayer(const string& cell_name, double n, double m);
+    NC_Cell * BuildNanotubeCell();
+    NC_Cell * BuildTestNanotubeCell();
+
+private:
+    vector<NC_NanotubeLayer> layers;
+};
 //------------------------------------------------------------------------------
 class CellData;
 

--- a/simncad/INCLUDE/WRAPPER/NC_Wrapper.h
+++ b/simncad/INCLUDE/WRAPPER/NC_Wrapper.h
@@ -18,6 +18,7 @@
 //#include <iostream>
 //==============================================================================
 class NC_Cell;
+class Nanotube;
 
 //typedef long id_t;
 typedef DWORD64 id_t;
@@ -178,9 +179,12 @@ public:
     void AddLayer(const string& cell_name, double n, double m);
     NC_Cell * BuildNanotubeCell();
     NC_Cell * BuildTestNanotubeCell();
+    void SetMaxBondDistance(double distance);
 
 private:
     vector<NC_NanotubeLayer> layers;
+    Nanotube * pNanotube;
+    double MaxBondDistance;
 };
 //------------------------------------------------------------------------------
 class CellData;
@@ -750,13 +754,16 @@ public:
   NC_Material *pMaterial;
 /**Pointer on the component crystal orientation*/  
   NC_CrystalOrientation *pOrientation; //3D, 2D, 1D, 0D ??
+/**Pointer on nanotube info*/
+  NC_Nanotube *pNanotube;
 
 /**NC_Component class constructor */
   NC_Component(
      const string &aName,
      NC_Shape *apShape,
      NC_Material *apMaterial,
-     NC_CrystalOrientation *apOrientation = NULL); 
+     NC_CrystalOrientation *apOrientation = NULL,
+     NC_Nanotube *apNanotube = NULL); 
 
 /**Destructor */  
   ~NC_Component();

--- a/simncad/INCLUDE_SIMPHONY/Factory_Shape.h
+++ b/simncad/INCLUDE_SIMPHONY/Factory_Shape.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 #define INVALID -999999
 
 using namespace std;
@@ -46,6 +47,9 @@ struct shape_info
     float y_pos_padding;
     float z_neg_padding;
     float z_pos_padding;
+    //Nanotube Ns and Ms
+    vector<int> ns;
+    vector<int> ms;
     shape_info();
 };
 /**Type for shape_info struct.*/

--- a/simncad/INCLUDE_SIMPHONY/NCadSimphonyWrapper.h
+++ b/simncad/INCLUDE_SIMPHONY/NCadSimphonyWrapper.h
@@ -440,6 +440,13 @@ public:
     void AddCell(CNCadParticleContainer *Cell, double a, double b, double c,
                             double alpha, double beta, double gamma,
                             int symmetry_gn);
+    /**Creates a nanotube cell for 1D components.
+    @param Cell the particle container for creation
+    @param cells the nanotube layers cells
+    @param n_values the n value for the layers
+    @param m_values the m value for the layers.*/
+    void CreateNanotubeCell(CNCadParticleContainer *Cell, vector<string> &cells, vector<double> n_values,
+                            vector<double> m_values);
     /**Deletes the specified component from nCad.
     @param name the name of the component.*/
     void RemoveComponent(string &name);

--- a/simncad/c_ncad.pxd
+++ b/simncad/c_ncad.pxd
@@ -1,3 +1,4 @@
+from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp.map cimport map
 from libcpp cimport bool 
@@ -30,6 +31,8 @@ cdef extern from "NCadSimphonyWrapper.h":
         void AddCell(CNCadParticleContainer *Cell, double a, double b, double c,
                             double alpha, double beta, double gamma,
                             int symmetry_gn) except +get_error_cython
+        void CreateNanotubeCell(CNCadParticleContainer *Cell, vector[string] &cells, vector[double] n_values,
+                                vector[double] m_values) except +get_error_cython
         void RemoveComponent(string &name) except +get_error_cython
         void RemoveCell(string &name) except +get_error_cython
         void TraceAll()

--- a/simncad/c_ncad.pxd
+++ b/simncad/c_ncad.pxd
@@ -147,6 +147,8 @@ cdef extern from "Factory_Shape.h":
         float y_pos_padding
         float z_neg_padding
         float z_pos_padding
+        vector[int] ns
+        vector[int] ms
 
 cdef extern from "NCadSimphonyWrapper.h":
     ctypedef struct CParticleContainerInfo:

--- a/simncad/ncad.pyx
+++ b/simncad/ncad.pyx
@@ -645,6 +645,11 @@ cdef class _NCadParticles:
             pc_info.shape_info.side = new_data[CUBA.SHAPE_SIDE]
         if CUBA.NAME_UC in new_data:
             pc_info.name_uc = new_data[CUBA.NAME_UC]
+        if CUBA.NANOTUBE_WALLS in new_data:
+            walls = new_data[CUBA.NANOTUBE_WALLS]
+            for wall in walls:
+                pc_info.shape_info.ns.push_back(wall[0])
+                pc_info.shape_info.ms.push_back(wall[1])
         self.thisptr.Update(pc_info)
         self._data = new_data
 
@@ -1212,6 +1217,14 @@ cdef class nCad:
             pc_info.shape_info.radius = new_component.data[CUBA.SHAPE_RADIUS]
         if CUBA.SHAPE_SIDE in new_component.data:
             pc_info.shape_info.side = new_component.data[CUBA.SHAPE_SIDE]
+        # Here treat the nanotube info in case we have it!
+        # Put it inside pc_info! #NANOTUBE
+        if CUBA.NANOTUBE_WALLS in new_component.data:
+            walls = new_component.data[CUBA.NANOTUBE_WALLS]
+            for wall in walls:
+                pc_info.shape_info.ns.push_back(wall[0])
+                pc_info.shape_info.ms.push_back(wall[1])
+
         self.thisptr.AddComponent(
                 <c_ncad.CNCadParticleContainer *>(ncpc.thisptr),
                 cell_name,

--- a/simncad/ncad.pyx
+++ b/simncad/ncad.pyx
@@ -932,7 +932,20 @@ cdef class nCad:
 
         """
         return self._get_particle_container(name)
-    
+
+    def get_dataset_names(self):
+        """Returns a list the dataset names in the engine's workspace.
+
+        Returns
+        -------
+        list :
+            list with the string names of the datasets.
+        """
+        names = []
+        for dataset in self.iter_datasets():
+            names.append(dataset.name)
+        return names
+
     def _get_particle_container(self, name):
         """Returns a _NCadParticles instance of the requested pc.
 
@@ -1220,7 +1233,14 @@ cdef class nCad:
         if (new_cell.name) in self._cells.keys():
             raise Exception('Duplicated particle container cell: {}'
                             .format(new_cell.name))
+
+        # Here we should do the checking for nanotube cells..
+        # 1. Check all the layers for the nanotube
+        # 2. Build the new cell
+        # 3. Apply the rest of parameters (if any)
+
         cdef _NCadParticles ncpc = _NCadParticles('cell')
+
         abc = new_cell.data[CUBA.LATTICE_UC_ABC]
         a = abc[0]
         b = abc[1]


### PR DESCRIPTION
- Added the capability of building nanotubes with the simphony-nCad wrapper:
  - The nanotubes are built adding a component with a 1D shape
  - The component has to have a 2D unit cell attached to it (and added to the nCad wrapper)
  - To indicate that is a nanotube it requires the CUBA.NANOTUBE_WALLS keyword in its data
    N,M pairs of the walls of the nanotube are added using the new CUBA.NANOTUBE_WALLS:
    data[CUBA.NANOTUBE_WALLS] = ((5,5), (10,10))
- Added missing ABCModellingEngine method
